### PR TITLE
Background channel is prematurely closed by the request object

### DIFF
--- a/examples/starlette_comparison.py
+++ b/examples/starlette_comparison.py
@@ -1,0 +1,82 @@
+import json
+import logging
+from typing import Iterable, Optional, Tuple
+
+from hypercorn.config import Config
+from hypercorn.trio import serve
+import trio
+
+from starlette.applications import Starlette
+from starlette.background import BackgroundTask
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.routing import Route
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+sh = logging.StreamHandler()
+logger.addHandler(sh)
+# Fake database
+DB = {}
+
+TEST_ROUTES = [
+    "/files/{dir}/{filepath:*}",
+    "/info/{user}",
+    "/info/{user}/project",
+    "/info/{user}/project/{project}",
+    "/info/{user}/project/{project}/dept",
+    "/info/{user}/project/{project}/dept/{dept}",
+    "/regex/{name:[a-zA-Z]+}/test",
+    (
+        "/optional/{name:[a-zA-Z]+}/{word}/plus/"
+        "{uid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}"
+    ),
+]
+
+
+async def bg_task(arg1=None):
+    for n in range(5):
+        logger.info(f"Sleeping 1s for total iterations: {n}")
+        await trio.sleep(1)
+    logger.info(f"Background DONE SLEEPING, with arg1 '{arg1}'")
+
+
+async def index(request):
+    return PlainTextResponse("ok")
+
+
+async def context_matcher(request: Request):
+    headers: Iterable[Tuple[bytes, bytes]] = request.scope.get("headers", [])
+    qparams: Optional[bytes] = request.scope.get("query_string")
+    http_version: Optional[str] = request.scope.get("http_version")
+    method: Optional[str] = request.scope.get("method")
+
+    task = BackgroundTask(bg_task, arg1="some kwarg")
+    # Dump out contents of request
+    logger.info(
+        (
+            f"{request.app.db=}, {request.path_params=}, "
+            f"{request.scope=}, {headers=}, {qparams=}, {http_version=}, {method=}"
+        )
+    )
+    message = await request.receive()
+    body = message.get("body") or b"{}"
+    payload = {"received": json.loads(body)}
+    request.app.db[request.url.path] = payload
+    return JSONResponse(payload, background=task)
+
+
+def make_router():
+    return [
+        Route("/", endpoint=index, methods=["GET"]),
+        *[Route(route, endpoint=context_matcher) for route in TEST_ROUTES],
+    ]
+
+
+if __name__ == "__main__":
+    config = Config()
+    config.bind = ["localhost:8000"]
+    app = Starlette(routes=make_router())
+    app.db = DB
+    trio.run(serve, app, config)

--- a/examples/tokamak_app.py
+++ b/examples/tokamak_app.py
@@ -36,7 +36,7 @@ async def lifespan(app: Tokamak, message_type: str = "") -> Tokamak:
 
 
 async def bg_task(arg1=None):
-    for n in range(10):
+    for n in range(5):
         logger.info(f"Sleeping 1s for total iterations: {n}")
         await trio.sleep(1)
     logger.info(f"Background DONE SLEEPING, with arg1 '{arg1}'")

--- a/examples/tokamak_app.py
+++ b/examples/tokamak_app.py
@@ -67,7 +67,10 @@ async def context_matcher(request: Request):
 
     # Dump out contents of request
     logger.info(
-        f"{request.app.db=}, {request.context=}, {request.scope=}, {headers=}, {qparams=}, {http_version=}, {method=}"
+        (
+            f"{request.app.db=}, {request.context=}, "
+            f"{request.scope=}, {headers=}, {qparams=}, {http_version=}, {method=}"
+        )
     )
     message = await request.receive()
     body = message.get("body") or b"{}"
@@ -80,7 +83,7 @@ async def context_matcher(request: Request):
 ROUTES = [
     Route("/", handler=index, methods=["GET"]),
     *[
-        Route(path, handler=context_matcher, methods=["POST"])
+        Route(path, handler=context_matcher, methods=["GET", "POST"])
         for path in [
             "/files/{dir}/{filepath:*}",
             "/info/{user}",

--- a/examples/tokamak_app.py
+++ b/examples/tokamak_app.py
@@ -43,20 +43,7 @@ async def bg_task(arg1=None):
 
 
 async def index(request: Request):
-    headers: Iterable[Tuple[bytes, bytes]] = request.scope.get("headers", [])
-    qparams: Optional[bytes] = request.scope.get("query_string")
-    http_version: Optional[str] = request.scope.get("http_version")
-    method: Optional[str] = request.scope.get("method")
-
-    logger.info(
-        f"{request.context=}, {request.scope=}, {headers=}, {qparams=}, {http_version=}, {method=}"
-    )
-
-    message = await request.receive()
-    body = message.get("body") or b"{}"
-    payload = json.dumps({"received": json.loads(body)}).encode("utf-8")
-    await request.respond_with(Response(body=payload))
-    await request.register_background(bg_task)
+    await request.respond_with(Response(body=b"ok"))
 
 
 async def context_matcher(request: Request):

--- a/tokamak/web/request.py
+++ b/tokamak/web/request.py
@@ -19,5 +19,4 @@ class Request:
             await self.responder.send(response)
 
     async def register_background(self, callable, args=None, kwargs=None):
-        async with self.background:
-            await self.background.send(callable)
+        await self.background.send(callable)


### PR DESCRIPTION
When attempting to run the experimental `Tokamak` application in the [`./examples`](./examples) directory, we found that the background channel was getting closed prematurely due to the context manager managing it being managed by the `Request`. 

That async context manager should instead be managed by the request -> response lifecycle.

This bug is seen when running the example app and sending multiple requests to it:

```sh
❯ poetry run python examples/tokamak_app.py
========·°·°~> Starting tokamak °°···°°🚀···°°
[2022-08-06 09:45:36 -0700] [65889] [INFO] Running on http://127.0.0.1:8000 (CTRL + C to quit)
...
trio.ClosedResourceError
```

This PR fixes this bug.