### PR TITLE
Clone channels for better shutdown

### DIFF
--- a/examples/simple_app.py
+++ b/examples/simple_app.py
@@ -60,12 +60,10 @@ async def handler(request: Request):
     body = message.get("body") or b"{}"
     payload = json.dumps({"received": json.loads(body)}).encode("utf-8")
     return Response(body=payload)
-    # await request.respond_with()
 
 
 async def basic_handler(request: Request):
     message = await request.receive()
-    # await request.respond_with()
     return Response(body=b"ok")
 
 

--- a/examples/simple_app.py
+++ b/examples/simple_app.py
@@ -59,12 +59,14 @@ async def handler(request: Request):
     message = await request.receive()
     body = message.get("body") or b"{}"
     payload = json.dumps({"received": json.loads(body)}).encode("utf-8")
-    await request.respond_with(Response(body=payload))
+    return Response(body=payload)
+    # await request.respond_with()
 
 
 async def basic_handler(request: Request):
     message = await request.receive()
-    await request.respond_with(Response(body=b"ok"))
+    # await request.respond_with()
+    return Response(body=b"ok")
 
 
 def make_router():

--- a/examples/tokamak_app.py
+++ b/examples/tokamak_app.py
@@ -42,7 +42,6 @@ async def bg_task(arg1=None):
 
 
 async def index(request: Request):
-    # await request.respond_with(Response(body=b"ok"))
     return Response(body=b"ok")
 
 
@@ -64,7 +63,6 @@ async def context_matcher(request: Request):
     payload = json.dumps({"received": json.loads(body)}).encode("utf-8")
     request.app.db[request.path] = payload
     await request.register_background(partial(bg_task, arg1="some kwarg"))
-    # await request.respond_with(Response(body=payload))
     return Response(body=payload)
 
 

--- a/examples/tokamak_app.py
+++ b/examples/tokamak_app.py
@@ -42,7 +42,8 @@ async def bg_task(arg1=None):
 
 
 async def index(request: Request):
-    await request.respond_with(Response(body=b"ok"))
+    # await request.respond_with(Response(body=b"ok"))
+    return Response(body=b"ok")
 
 
 async def context_matcher(request: Request):
@@ -62,8 +63,9 @@ async def context_matcher(request: Request):
     body = message.get("body") or b"{}"
     payload = json.dumps({"received": json.loads(body)}).encode("utf-8")
     request.app.db[request.path] = payload
-    await request.respond_with(Response(body=payload))
     await request.register_background(partial(bg_task, arg1="some kwarg"))
+    # await request.respond_with(Response(body=payload))
+    return Response(body=payload)
 
 
 ROUTES = [

--- a/tokamak/router.py
+++ b/tokamak/router.py
@@ -65,8 +65,8 @@ class AsgiRouter:
             message = await request.receive()
             body = message.get("body") or b"{}"
             payload = json.dumps({"received": json.loads(body)}).encode("utf-8")
-            await request.respond_with(Response(body=payload))
             await request.register_background(partial(bg_task, arg1="some kwarg"))
+            return Response(body=payload)
 
 
         AsgiRouter(routes=[

--- a/tokamak/web/app.py
+++ b/tokamak/web/app.py
@@ -96,13 +96,7 @@ class Tokamak:
 
         # resp_send_chan, resp_recv_chan = trio.open_memory_channel(1)
 
-        request = Request(
-            context,
-            scope,
-            receive,
-            path,  # resp_send_chan.clone(),
-            self.bg_send_chan.clone(),
-        )
+        request = Request(context, scope, receive, path, self.bg_send_chan.clone(),)
 
         async with self.bg_send_chan, self.bg_recv_chan:
             # Run handler
@@ -129,37 +123,8 @@ class Tokamak:
             else:
                 await send({"type": "http.response.body", "body": response.body})
 
-                # Send response to client
-                # async for response in resp_recv_chan:
-                #     await send(
-                #         {
-                #             "type": "http.response.start",
-                #             "status": response.status_code,
-                #             "headers": response.raw_headers,
-                #         }
-                #     )
-                #     if response.streaming:
-                #         async for chunk in response.streaming_body:
-                #             await send(
-                #                 {
-                #                     "type": "http.response.body",
-                #                     "body": chunk,
-                #                     "more_body": True,
-                #                 }
-                #             )
-                #         await send(
-                #             {
-                #                 "type": "http.response.body",
-                #                 "body": b"",
-                #                 "more_body": False,
-                #             }
-                #         )
-                #     else:
-                #         await send(
-                #             {"type": "http.response.body", "body": response.body}
-                #         )
             # Run background
-            async for background_task in self.bg_recv_chan.clone():
+            async for background_task in self.bg_recv_chan:
                 await background_task()
 
         return None

--- a/tokamak/web/app.py
+++ b/tokamak/web/app.py
@@ -94,47 +94,72 @@ class Tokamak:
         path: str = scope.get("path", "")
         route, context = self.router.get_route(path)
 
-        resp_send_chan, resp_recv_chan = trio.open_memory_channel(1)
+        # resp_send_chan, resp_recv_chan = trio.open_memory_channel(1)
 
         request = Request(
-            context, scope, receive, path, resp_send_chan, self.bg_send_chan
+            context,
+            scope,
+            receive,
+            path,  # resp_send_chan.clone(),
+            self.bg_send_chan.clone(),
         )
 
         async with self.bg_send_chan, self.bg_recv_chan:
-            async with resp_recv_chan:
-                # Run handler
-                await route(request, method=scope.get(methods.SCOPE_METHOD_KEY))
-                # Send response to client
-                async for response in resp_recv_chan:
+            # Run handler
+            response = await route(request, method=scope.get(methods.SCOPE_METHOD_KEY))
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": response.status_code,
+                    "headers": response.raw_headers,
+                }
+            )
+            if response.streaming:
+                async for chunk in response.streaming_body:
                     await send(
                         {
-                            "type": "http.response.start",
-                            "status": response.status_code,
-                            "headers": response.raw_headers,
+                            "type": "http.response.body",
+                            "body": chunk,
+                            "more_body": True,
                         }
                     )
-                    if response.streaming:
-                        async for chunk in response.streaming_body:
-                            await send(
-                                {
-                                    "type": "http.response.body",
-                                    "body": chunk,
-                                    "more_body": True,
-                                }
-                            )
-                        await send(
-                            {
-                                "type": "http.response.body",
-                                "body": b"",
-                                "more_body": False,
-                            }
-                        )
-                    else:
-                        await send(
-                            {"type": "http.response.body", "body": response.body}
-                        )
+                await send(
+                    {"type": "http.response.body", "body": b"", "more_body": False,}
+                )
+            else:
+                await send({"type": "http.response.body", "body": response.body})
+
+                # Send response to client
+                # async for response in resp_recv_chan:
+                #     await send(
+                #         {
+                #             "type": "http.response.start",
+                #             "status": response.status_code,
+                #             "headers": response.raw_headers,
+                #         }
+                #     )
+                #     if response.streaming:
+                #         async for chunk in response.streaming_body:
+                #             await send(
+                #                 {
+                #                     "type": "http.response.body",
+                #                     "body": chunk,
+                #                     "more_body": True,
+                #                 }
+                #             )
+                #         await send(
+                #             {
+                #                 "type": "http.response.body",
+                #                 "body": b"",
+                #                 "more_body": False,
+                #             }
+                #         )
+                #     else:
+                #         await send(
+                #             {"type": "http.response.body", "body": response.body}
+                #         )
             # Run background
-            async for background_task in self.bg_recv_chan:
+            async for background_task in self.bg_recv_chan.clone():
                 await background_task()
 
         return None

--- a/tokamak/web/request.py
+++ b/tokamak/web/request.py
@@ -2,12 +2,12 @@ from tokamak.web.response import Response
 
 
 class Request:
-    def __init__(self, context, scope, receive, path, response_chan, background_chan):
+    def __init__(self, context, scope, receive, path, background_chan):
         self.context = context
         self.scope = scope
         self.receive = receive
         self.path = path
-        self.responder = response_chan
+        # self.responder = response_chan
         self.background = background_chan
 
     @property
@@ -19,4 +19,5 @@ class Request:
             await self.responder.send(response)
 
     async def register_background(self, callable, args=None, kwargs=None):
-        await self.background.send(callable)
+        async with self.background:
+            await self.background.send(callable)

--- a/tokamak/web/request.py
+++ b/tokamak/web/request.py
@@ -14,10 +14,6 @@ class Request:
     def app(self):
         return self.scope.get("app")
 
-    async def respond_with(self, response: Response):
-        async with self.responder:
-            await self.responder.send(response)
-
     async def register_background(self, callable, args=None, kwargs=None):
         async with self.background:
             await self.background.send(callable)


### PR DESCRIPTION
We were not properly sharing channels between processes and this causes the application to hang when attempting to shut it down [see trio docs](https://trio.readthedocs.io/en/stable/reference-core.html#managing-multiple-producers-and-or-multiple-consumers). 

This PR removes response channels and expects a `Response` returned. In addition, it now clones the background channel for the handler tasks.