### PR TITLE
Fix requirement for mkdocs-gen-files

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -9,7 +9,8 @@ mkautodoc==0.2.0
 mkdocs-coverage==0.2
 markdown-callouts==0.2
 markdown-exec==0.5
-mkdocs-gen-files==0.3
+mkdocs-gen-files==0.3.5
 mkdocs-literate-nav==0.4
 mkdocs-material==7.3
+mkdocs-material-extensions==1.0.3
 mkdocs-section-index==0.3


### PR DESCRIPTION
Bad requirement made readthedocs fail.