### PR TITLE
Twine dependency is not installed on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
       - name: "Configure poetry"
         run: "poetry config virtualenvs.create false --local"
       - name: "Run poetry update"
+        run: "poetry update"
+      - name: "Run poetry build"
         run: "poetry build"
       - name: "Publish to PyPI & deploy docs"
         run: "scripts/release.sh"


### PR DESCRIPTION
The Github action workflow that runs `twine update` did not previously include an installed of `twine`. As a result, it failed.

This PR adds depedency-loading to this project.