### PR TITLE
Fix Release Github Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,8 @@ jobs:
         run: "poetry update"
       - name: "Run tests"
         run: "scripts/run_tests.sh"
+      # DELETE ME
+      - name: "Run poetry build"
+        run: "poetry build"
+      - name: "Run poetry build"
+        run: "poetry run twine check dist/*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,3 @@ jobs:
         run: "poetry update"
       - name: "Run tests"
         run: "scripts/run_tests.sh"
-      # DELETE ME
-      - name: "Twinning"
-        run: "pip install twine && twine check dist/*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.9", "3.10"]
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,5 @@ jobs:
       - name: "Run tests"
         run: "scripts/run_tests.sh"
       # DELETE ME
-      - name: "Run poetry build"
-        run: "poetry build"
-      - name: "Run poetry build"
-        run: "poetry run twine check dist/*"
+      - name: "Twinning"
+        run: "pip install twine && twine check dist/*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     environment:
-      name: deploy
+      name: PyPi
 
     steps:
       - uses: "actions/checkout@v3"
@@ -24,8 +24,8 @@ jobs:
         run: "poetry update"
       - name: "Run poetry build"
         run: "poetry build"
-      - name: "Publish to PyPI & deploy docs"
-        run: "scripts/release.sh"
+      - name: "Publish to PyPI"
+        run: "pip install twine && scripts/release.sh"
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,10 +22,8 @@ jobs:
         run: "poetry config virtualenvs.create false --local"
       - name: "Run poetry update"
         run: "poetry update"
-      - name: "Run poetry build"
-        run: "poetry build"
       - name: "Publish to PyPI"
-        run: "pip install twine && scripts/release.sh"
+        run: "scripts/release.sh"
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
 
 poetry build
-poetry run twine check dist/*
-poetry run twine upload dist/*
+twine check dist/*
+twine upload dist/*

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
 
 poetry build
-twine check dist/*
-twine upload dist/*
+python -m twine check dist/*
+python -m twine upload dist/*


### PR DESCRIPTION
The release github action does not seem to run twine under poetry. The strategy here will be to run it as a python module.